### PR TITLE
chore: add DeepWiki badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@
 
 <p align="center"><a href="https://rubygems.org/gems/rudder_analytics_sync/"><img src="https://img.shields.io/gem/v/rudder_analytics_sync?style=flat"/></a></p>
 
+<p align="center"><a href="https://deepwiki.com/rudderlabs/rudder-sdk-ruby-sync"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki"/></a></p>
+
 ----
 
 # RudderStack Ruby SDK


### PR DESCRIPTION
# Description

Add a DeepWiki badge to the README.md file. The badge links to the [DeepWiki page for this repository](https://deepwiki.com/rudderlabs/rudder-sdk-ruby-sync), providing an easy entry point for AI-powered documentation and codebase exploration.

This is a non-functional change that only modifies the README — no code, tests, or dependencies are affected.
